### PR TITLE
Add extra fields to configuration

### DIFF
--- a/freshchat/client/configuration.py
+++ b/freshchat/client/configuration.py
@@ -12,6 +12,8 @@ class FreshChatConfiguration:
 
     app_id: str
     token: str = field(repr=False)
+    default_channel_id: Optional[str] = field(default=None)
+    default_initial_message: Optional[str] = field(default=None)
     url: Optional[str] = field(
         default_factory=lambda: os.environ.get(
             "FRESHCHAT_API_URL", "https://api.freshchat.com/v2/"


### PR DESCRIPTION
Add default values in the case channel id or initial message are not
provided by the user