### PR TITLE
Add public_key attribute to FreshChatConfiguration

### DIFF
--- a/freshchat/client/configuration.py
+++ b/freshchat/client/configuration.py
@@ -12,6 +12,7 @@ class FreshChatConfiguration:
 
     app_id: str
     token: str = field(repr=False)
+    public_key: str = field(repr=False)
     default_channel_id: Optional[str] = field(default=None)
     default_initial_message: Optional[str] = field(default=None)
     url: Optional[str] = field(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -34,7 +34,12 @@ def token():
 @pytest.fixture
 def test_config(token) -> FreshChatConfiguration:
     return FreshChatConfiguration(
-        **{"app_id": str(uuid4()), "default_channel_id": str(uuid4()), "token": token}
+        **{
+            "app_id": str(uuid4()),
+            "default_channel_id": str(uuid4()),
+            "token": token,
+            "public_key": "-----BEGIN RSA PUBLIC KEY-----*****-----END RSA PUBLIC KEY-----",
+        }
     )
 
 


### PR DESCRIPTION
We need to add public_key attribute to configuration to have the
ability to save it in redis and reach it from api repo at any time we
need

Closes: #14 